### PR TITLE
Ignore locally-generated native messaging host

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.pyc
+/native/textern.json


### PR DESCRIPTION
Since this file is locally generated/customized, it can't (and shouldn't) be tracked in version control.