### PR TITLE
compat: new inotify_simple

### DIFF
--- a/native/textern.py
+++ b/native/textern.py
@@ -14,7 +14,11 @@ import sys
 import tempfile
 import urllib.parse
 
-from inotify_simple.inotify_simple import INotify, flags
+try:
+    from inotify_simple import INotify, flags
+except ImportError:
+    # fall-back to the old import pattern for git-submodule use-case (PR#57)
+    from inotify_simple.inotify_simple import INotify, flags
 
 
 class TmpManager():


### PR DESCRIPTION
In new inotify_simple there's no `inotify_simple/inotify_simple.py`
file, but only `inotify_simple.py`.  So fix the import.  This should be
also compatible with previous versions of inotify_simple where they did
`from .inotify_simple import *` inside `__init__.py`.