### PR TITLE
Add debugging aids

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Some things to try if it doesn't work properly:
  * Try configuring Textern to launch using a different shortcut
  * Try configuring Textern to use the following as the external editor: `["sh", "-c", "echo foobar > $0"]` (that should just echo foobar into the textarea box)
  * Check the browser console for errors (Ctrl+Shift+J)
+ * Check the extension's console for errors (Go to `about:debugging`, find Textern in the list of extensions, and click Inspect)
  * Make sure you cloned the repo with `--recurse-submodules` (see installation instructions above)
  * Try re-installing but for your local user (`make native-install USER=1` instead of `sudo make native-install`)
  * Check if Textern is running in the background (`ps aux | grep textern`)

--- a/webex/background.js
+++ b/webex/background.js
@@ -79,6 +79,14 @@ function registerDoc(tid, eid, text, caret, url) {
         port.onMessage.addListener((response) => {
             handleNativeMessage(response);
         });
+        port.onDisconnect.addListener((p) => {
+            console.log("Disconnected from helper");
+            if (p.error) {
+                logError(p.error);
+            }
+            activeDocs = [];
+            port = undefined;
+        });
     }
 
     browser.storage.local.get({


### PR DESCRIPTION
I've been toying with the idea of implementing Textern's native helper executable in Rust, so I can make a single self-contained executable that automatically generates a manifest and installs it in the correct place, etc. Every time my native helper crashes, I have to go into Firefox's Addon Manager, disable Textern and re-enable it, otherwise I get "This text is already being edited" errors and the native helper is not restarted.

With this change, when the native helper crashes, it logs the error to the extension console (instead of silently ignoring it) and clears `activeDocs` and `port` so the helper will be automatically restarted next time it's needed.