### PR TITLE
Add support for a backup directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,19 @@ For example, to use the GNOME gedit flatpak, use:
 ["flatpak", "run", "--filesystem=xdg-run/textern", "org.gnome.gedit"]
 ```
 
+### Enabling backups
+
+Textern has experimental support for backing up text to a
+separate location to allow recovering data inadvertently
+lost by closing a tab or Firefox too soon. To enable this
+feature, enter a path to the backup directory in the addon
+preferences page. Note no shell expansion is performed on
+the path (use e.g. `/home/jlebon` instead of `~`).
+
+Files older than 24 hours are deleted from the backup
+directory. Note this feature is experimental and subject to
+change.
+
 ## Troubleshooting
 
 Some things to try if it doesn't work properly:

--- a/webex/background.js
+++ b/webex/background.js
@@ -91,7 +91,8 @@ function registerDoc(tid, eid, text, caret, url) {
 
     browser.storage.local.get({
         editor: "[\"gedit\", \"+%l:%c\"]",
-        extension: "txt"
+        extension: "txt",
+        backupdir: ""
     }).then(values => {
         port.postMessage({
             type: "new_text",
@@ -102,7 +103,8 @@ function registerDoc(tid, eid, text, caret, url) {
                 url: url,
                 prefs: {
                     editor: values.editor,
-                    extension: values.extension
+                    extension: values.extension,
+                    backupdir: values.backupdir
                 }
             }
         });

--- a/webex/options.html
+++ b/webex/options.html
@@ -18,6 +18,8 @@
       <label for="extension">Document extension</label>
       <input type="text" id="extension" required=true pattern="[.a-zA-Z0-9_-]+"
              title='Must be an alphanumerical string (excluding leading dot)'>
+      <label for="backupdir">Backup files to directory (experimental)</label>
+      <input type="text" id="backupdir">
       <button type="submit">Save</button><span id="saved"></span>
     </form>
     <script src="options.js" charset="utf-8"></script>

--- a/webex/options.js
+++ b/webex/options.js
@@ -15,7 +15,8 @@ function saveOptions(e) {
     browser.storage.local.set({
         editor: document.querySelector("#editor").value,
         shortcut: document.querySelector("#shortcut").value,
-        extension: document.querySelector("#extension").value
+        extension: document.querySelector("#extension").value,
+        backupdir: document.querySelector("#backupdir").value
     });
     document.querySelector("#saved").innerHTML = '\u2713';
 }
@@ -37,6 +38,10 @@ function restoreOptions() {
 
     browser.storage.local.get("extension").then(result => {
         document.querySelector("#extension").value = result.extension || "txt";
+    }, onError);
+
+    browser.storage.local.get("backupdir").then(result => {
+        document.querySelector("#backupdir").value = result.backupdir || "";
     }, onError);
 }
 


### PR DESCRIPTION
If by accident, one closes the tab or closes Firefox by accident before submitting your work, you could lose all the text you've written. Add an experimental option to allow copying the text files into a backup directory. Backups are updated on every save and kept for 24 hours before being pruned.

Closes: #83