### PR TITLE
Trigger input event after updating textarea

### DIFF
--- a/webex/content.js
+++ b/webex/content.js
@@ -119,6 +119,8 @@ function setText(id, text) {
     var e = elements.get(id);
     if (e.nodeName == "TEXTAREA") {
         e.value = text;
+        /* send input event to make website (p.e. tiddlywiki.com) aware of updated text */
+        e.dispatchEvent(new Event('input', {}));
     } else if ((e.nodeName == "DIV") && e.contentEditable) {
         if (isSlackMessage(e)) {
             e.innerHTML = textToSlackMessageDiv(text);


### PR DESCRIPTION
Trigger input event after updating a textarea with textern to make website aware of changed text. This is necessary on <https://tiddlywiki.com>.

