### PR TITLE
README.md: clarify backup directory selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,9 +161,14 @@ feature, enter a path to the backup directory in the addon
 preferences page. Note no shell expansion is performed on
 the path (use e.g. `/home/jlebon` instead of `~`).
 
-Files older than 24 hours are deleted from the backup
-directory. Note this feature is experimental and subject to
-change.
+**All files** older than 24 hours are deleted from the
+backup directory (i.e., not just those files that Textern
+created). If there are files in the directory that Textern
+fails to delete, then Textern will misbehave. For this
+reason, make sure the backup directory is exclusively used
+by Textern.
+
+Note this feature is experimental and subject to change.
 
 ## Troubleshooting
 


### PR DESCRIPTION
I mistakenly specified /tmp as my Textern backup directory. Two bad consequences:

- Textern would remove my files under /tmp that Textern didn't create.

- Textern would attempt deleteing files under /tmp that were not owned by me, and throw an exception from os.unlink() in update_backupdir(). The exception would be lost (i.e., not propagated to Firefox), and I'd only see Textern silently not work.

Help other users avoid this configuration mistake: document that the Textern backup directory should be exclusively dedicated to Textern.